### PR TITLE
Test for non-server messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,7 +96,7 @@ bot.on('ready', () => {
 
 // Handle messages
 bot.on('message', message => {
-  if (!message.author.bot) { // No bots!
+  if (!message.author.bot && message.guild) { // No bots or non-server messages
 
     let commandText;
 


### PR DESCRIPTION
This fixes a case where a non-server message would lead to a null dereference for `message.guild.roles` for a DM, which has no `guild` field.