### PR TITLE
Add basic Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:7.1
+MAINTAINER John Marion <john@lmsn.net>
+
+# https://serverfault.com/questions/96416/-/96420#96420
+COPY . /opt/DiscoBot/
+WORKDIR /opt/DiscoBot/
+
+RUN npm install
+
+CMD [ "node", "index.js" ]


### PR DESCRIPTION
This is just a simple Dockerfile to run the bot, currently pinned to Node 7.1.

I'm still working on setting up a test bot for myself, but I at least get far enough to get the "No auth token found". I'll revise this if it turns out to not work at all.