### PR TITLE
Add reply to check DMs for !help

### DIFF
--- a/commands/help.js
+++ b/commands/help.js
@@ -74,5 +74,10 @@ module.exports = {
         message.author.sendMessage(commandArray[i]);
       }
     }
+
+    // If !help was run in a public channel, send a message to that channel too
+    if (message.channel.type === 'text') {
+      message.reply('Check your DMs :wink:');
+    }
   }
 };


### PR DESCRIPTION
This makes DiscoBot reply to the !help command in public channels letting the user know to check their DMs. This also lets other users in the channel see that the command did something.