### PR TITLE
Make the !choose command respect quotes

### DIFF
--- a/commands/choose.js
+++ b/commands/choose.js
@@ -1,3 +1,5 @@
+const splitargs = require("splitargs");
+
 module.exports = {
   usage: '[Option 1] [Option 2] [etc]',
   description: 'Let DiscoBot choose for you.',
@@ -13,7 +15,7 @@ module.exports = {
       'I choose \"%\"'
     ];
 
-    let choices = message.content.split(/\s*[ ,;]\s*|\sor\s/i);
+    let choices = splitargs(message.content);
     choices.shift();
 
     let choice = choices[Math.floor(Math.random() * choices.length)];

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "moment": "^2.13.0",
     "moment-timezone": "^0.5.4",
     "node-cron": "^1.1.2",
-    "request": "^2.74.0"
+    "request": "^2.74.0",
+    "splitargs": "^0.0.7"
   },
   "engines": {
     "node": "^6.4.0"


### PR DESCRIPTION
This makes the !choose command understand spaces in possible options when enclosed in quotes.
For example, `!choose "Option One" "Option Two"` is split up as such: `["Option One", "Option Two"]`.

<3 @Reynbow
