### PR TITLE
Add check that command actually exists

### DIFF
--- a/index.js
+++ b/index.js
@@ -153,6 +153,10 @@ function messageHandler(message) {
     return;
   }
 
+  // If we couldn't find any command, cut out
+  if (!command)
+    return;
+
   command.process(bot, message, permission);
 }
 


### PR DESCRIPTION
If a command is run that doesn't exist (ie `!notacommand`), we would still try to run `.process` from the `commands` array. This checks that the command exists before we try to run it.