### PR TITLE
Add allowDM and requireRoles fields to commands, Add role bot restrictions

### DIFF
--- a/admin-commands/timeout.js
+++ b/admin-commands/timeout.js
@@ -5,6 +5,7 @@ const format = require('../momentFormat');
 module.exports = {
   usage: '[@user]',
   description: 'ADMIN ONLY: Give a user the \'Restricted\' role for 30 minutes. Will also remove the \'18+\' role.',
+  allowDM: false,
   process: (bot, message) => {
     let timeoutEnd = Date.now() + 1800000;
 

--- a/commands/avatar.js
+++ b/commands/avatar.js
@@ -1,6 +1,7 @@
 module.exports = {
   usage: '[@user]',
   description: 'See someone\'s avatar.',
+  allowDM: true,
   process: (bot, message) => {
     for (var [id, user] of message.mentions.users) {
       if (user.avatarURL) {

--- a/commands/boop.js
+++ b/commands/boop.js
@@ -1,6 +1,7 @@
 module.exports = {
   usage: '[@user]',
   description: 'BOOP',
+  allowDM: true,
   process: (bot, message) => {
 
     const boopReplies = [

--- a/commands/cat.js
+++ b/commands/cat.js
@@ -3,6 +3,7 @@ const request = require('request');
 module.exports = {
   usage: '',
   description: 'Gets a random cat picture.',
+  allowDM: true,
   process: (bot, message) => {
     // http://random.cat/meow
     request('http://random.cat/meow', (error, response, body) => {

--- a/commands/choose.js
+++ b/commands/choose.js
@@ -1,8 +1,9 @@
-const splitargs = require("splitargs");
+const splitargs = require('splitargs');
 
 module.exports = {
   usage: '[Option 1] [Option 2] [etc]',
   description: 'Let DiscoBot choose for you.',
+  allowDM: true,
   process: (bot, message) => {
 
     const responses = [

--- a/commands/getinfo.js
+++ b/commands/getinfo.js
@@ -3,6 +3,7 @@ const firebase = require('firebase');
 module.exports = {
   usage: '[service (optional)] [@user (optional)]',
   description: 'Gets user\'s saved info from the database',
+  allowDM: true,
   process: (bot, message) => {
 
     let user;

--- a/commands/help.js
+++ b/commands/help.js
@@ -3,6 +3,7 @@ const commands = require('../index');
 module.exports = {
   usage: '',
   description: 'See what commands I can run!',
+  allowDM: true,
   process: (bot, message, permission) => {
     let firstMessage = 'Available Commands';
     let commandString = '```';

--- a/commands/help.js
+++ b/commands/help.js
@@ -4,14 +4,20 @@ module.exports = {
   usage: '',
   description: 'See what commands I can run!',
   allowDM: true,
-  process: (bot, message, permission) => {
+  process: (bot, message) => {
     let firstMessage = 'Available Commands';
     let commandString = '```';
     let commandArray = [];
 
-    for (var command in commands.commands) {
+    // TODO: Display commands based on requireRoles
+    for (let command in commands.commands) {
       let cmd = commands.commands[command];
       let info = '!' + command;
+
+      // Skip commands that require roles for now
+      if (cmd.requireRoles) {
+        continue;
+      }
 
       if (cmd.usage) {
         info += ' ' + cmd.usage;
@@ -37,43 +43,6 @@ module.exports = {
 
     for (let i = 0; i < commandArray.length; i++) {
       message.author.sendMessage(commandArray[i]);
-    }
-
-    // Admin commands
-    if (permission) {
-      let adminMessage = 'Admin only commands';
-      commandString = '```';
-      commandArray = [];
-
-      for (var command in commands.adminCommands) {
-        let cmd = commands.adminCommands[command];
-        let info = '!' + command;
-
-        if (cmd.usage) {
-          info += ' ' + cmd.usage;
-        }
-
-        if (cmd.description) {
-          info += ' - ' + cmd.description;
-        }
-
-        if ((commandString.length + info.length) < 1900) {
-          commandString += info + '\n';
-        } else {
-          commandString += '```';
-          commandArray.push(commandString);
-          commandString = '```'; // Reset
-          commandString += info + '\n';
-        }
-      }
-      commandString += '```';
-      commandArray.push(commandString);
-
-      message.author.sendMessage(adminMessage);
-
-      for (let i = 0; i < commandArray.length; i++) {
-        message.author.sendMessage(commandArray[i]);
-      }
     }
 
     // If !help was run in a public channel, send a message to that channel too

--- a/commands/hug.js
+++ b/commands/hug.js
@@ -1,6 +1,7 @@
 module.exports = {
   usage: '[@user]',
   description: 'Give someone a hug :blush:',
+  allowDM: true,
   process: (bot, message) => {
 
     const hugReplies = [

--- a/commands/joined.js
+++ b/commands/joined.js
@@ -4,6 +4,7 @@ const format = require('../momentFormat');
 module.exports = {
   usage: '[@user]',
   description: 'See when someone joined the server.',
+  allowDM: false,
   process: (bot, message) => {
     for (var [id, user] of message.mentions.users) {
 

--- a/commands/magic8ball.js
+++ b/commands/magic8ball.js
@@ -1,6 +1,7 @@
 module.exports = {
   usage: '[question]',
   description: 'See the future, have DiscoBot read your fortune.',
+  allowDM: true,
   process: (bot, message) => {
 
     const responses = [

--- a/commands/penguin.js
+++ b/commands/penguin.js
@@ -3,6 +3,7 @@ const request = require('request');
 module.exports = {
   usage: '',
   description: 'Gets a random penguin picture.',
+  allowDM: true,
   process: (bot, message) => {
     // http://penguin.wtf
     request('http://penguin.wtf', (error, response, body) => {

--- a/commands/regions.js
+++ b/commands/regions.js
@@ -1,6 +1,7 @@
 module.exports = {
   usage: '',
   description: 'Lists all available regions for use with the !setregion command.',
+  allowDM: true,
   process: (bot, message) => {
     message.reply(
       'To set your region type `!setregion [Your region]` in any channel. \n' +

--- a/commands/role.js
+++ b/commands/role.js
@@ -3,13 +3,8 @@ const roles = require('../roles');
 module.exports = {
   usage: 'add/remove [role]',
   description: 'Set or remove a role from yourself.',
+  allowDM: false,
   process: (bot, message) => {
-    // This command doesn't make sense in a DM
-    if (message.channel.type !== 'text') {
-      message.reply('Sorry... I can\'t set roles within a DM.');
-      return;
-    }
-
     let msg = message.content;
 
     // Some users mis-read the usage text and assume that they need to

--- a/commands/set18.js
+++ b/commands/set18.js
@@ -1,13 +1,8 @@
 module.exports = {
   usage: '',
   description: 'Gives you the 18+ role, allows access to #over-18 and #over-18-text.',
+  allowDM: false,
   process: (bot, message) => {
-    // Error check so not in PM
-    if (message.channel.type !== 'text') {
-      message.reply('sorry... I can\'t set 18+ inside private messages.');
-      return;
-    }
-
     let role = message.guild.roles.find('name', '18+');
     let under18 = message.guild.roles.find('name', 'Under 18');
     let member = message.guild.member(message.author);
@@ -20,7 +15,7 @@ module.exports = {
         message.reply('you\'ve already been set to ' + role.name);
         return;
       }
-      
+
       // Check if member has under18 role.
       if (currentRole === under18){
       	message.reply('You are under 18 years of age. I cannot add the 18+ role. :frowning: ');

--- a/commands/setinfo.js
+++ b/commands/setinfo.js
@@ -4,6 +4,7 @@ module.exports = {
   usage: '[service] [username]',
   description: 'Save your gamertag/username for any gaming service to ' +
     'the database.',
+  allowDM: true,
   process: (bot, message) => {
     let msg = message.content;
 

--- a/commands/setregion.js
+++ b/commands/setregion.js
@@ -3,13 +3,8 @@ const REGIONS = require('../roles').REGION_ROLES;
 module.exports = {
   usage: '[your region]',
   description: 'Set your region, get pretty color.',
+  allowDM: false,
   process: (bot, message) => {
-    // This command doesn't make sense in a DM
-    if (message.channel.type !== 'text') {
-      message.reply('Sorry... I can\'t set your region in a DM.');
-      return;
-    }
-
     let msg = message.content.split(' ');
 
     // Remove the first element, as it will be '!setregion'

--- a/commands/slap.js
+++ b/commands/slap.js
@@ -1,6 +1,7 @@
 module.exports = {
   usage: '[@user]',
   description: 'Slap someone that deserves it.',
+  allowDM: true,
   process: (bot, message) => {
 
     const slapReplies = [

--- a/commands/spray.js
+++ b/commands/spray.js
@@ -1,6 +1,7 @@
 module.exports = {
   usage: '[@user]',
   description: 'Spray someone thirsty...',
+  allowDM: true,
   process: (bot, message) => {
 
     const sprayReplies = [

--- a/commands/timeout.js
+++ b/commands/timeout.js
@@ -6,6 +6,7 @@ module.exports = {
   usage: '[@user]',
   description: 'ADMIN ONLY: Give a user the \'Restricted\' role for 30 minutes. Will also remove the \'18+\' role.',
   allowDM: false,
+  requireRoles: ['Admin', 'Moderator'],
   process: (bot, message) => {
     let timeoutEnd = Date.now() + 1800000;
 

--- a/commands/unset18.js
+++ b/commands/unset18.js
@@ -1,13 +1,8 @@
 module.exports = {
   usage: '',
   description: 'Removes the 18+ role.',
+  allowDM: false,
   process: (bot, message) => {
-    // Error check so not in PM
-    if (message.channel.type !== 'text') {
-      message.reply('sorry... I can\'t remove 18+ inside private messages.');
-      return;
-    }
-
     let member = message.guild.member(message.author);
     let role = message.guild.roles.find('name', '18+');
     let currentRoles = [];

--- a/commands/unsetinfo.js
+++ b/commands/unsetinfo.js
@@ -3,6 +3,7 @@ const firebase = require('firebase');
 module.exports = {
   usage: '[service (optional)]',
   description: 'Delete a gamertag/username, or all your saved data.',
+  allowDM: true,
   process: (bot, message) => {
     let msg = message.content.split(' ');
 

--- a/commands/unsetregion.js
+++ b/commands/unsetregion.js
@@ -1,13 +1,8 @@
 module.exports = {
   usage: '',
   description: 'Remove your region, remain mysterious.',
+  allowDM: false,
   process: (bot, message) => {
-    // Error check so not in PM
-    if (message.channel.type !== 'text') {
-      message.reply('sorry... I can\'t remove your region inside private messages.');
-      return;
-    }
-
     let member = message.guild.member(message.author);
     let currentRoles = [];
 

--- a/cronjobs/check-timeout.js
+++ b/cronjobs/check-timeout.js
@@ -1,6 +1,6 @@
 const firebase = require('firebase');
 const moment = require('moment');
-const format = require('../../momentFormat');
+const format = require('../momentFormat');
 
 module.exports = {
   process: (bot) => {

--- a/index.js
+++ b/index.js
@@ -121,6 +121,13 @@ function messageHandler(message) {
   let permission = false;
   let adminCommand = false;
 
+  // If a command isn't allowed in a DM (or doesn't have allowDM defined),
+  // make sure we're in a guild.
+  if (command && !command.allowDM && !message.guild) {
+    message.reply('Sorry, I can only do that on a server. :frowning2:');
+    return;
+  }
+
   // If we're in a guild, check for admin/mod. If not (ie DM), assume
   // they're a normal user. This allows some commands to be run outside of
   // a guild context.

--- a/index.js
+++ b/index.js
@@ -1,8 +1,10 @@
+const cron = require('node-cron');
 const Discord = require('discord.js');
 const firebase = require('firebase');
 const moment = require('moment');
+
 const format = require('./momentFormat');
-const cron = require('node-cron');
+const roles = require('./roles');
 
 require('./utils');
 
@@ -42,7 +44,7 @@ const config = {
 firebase.initializeApp(config);
 
 // Commands
-let commands = {};
+const commands = {};
 
 // Import commands
 commands.avatar = require('./commands/avatar');
@@ -65,19 +67,13 @@ commands.spray = require('./commands/spray');
 commands.unset18 = require('./commands/unset18');
 commands.unsetinfo = require('./commands/unsetinfo');
 commands.unsetregion = require('./commands/unsetregion');
-
-// Admin commands
-let adminCommands = {};
-
-// Import admin commands
-adminCommands.timeout = require('./admin-commands/timeout');
+commands.timeout = require('./commands/timeout');
 
 // Export commands for use in other modules (help)
 module.exports.commands = commands;
-module.exports.adminCommands = adminCommands;
 
 // Events
-let events = {};
+const events = {};
 
 // Import events
 events.memberBanned = require('./events/memberBanned');
@@ -89,10 +85,10 @@ events.messageDeleted = require('./events/messageDeleted');
 events.messageUpdated = require('./events/messageUpdated');
 
 // Cron
-let cronJobs = {};
+const cronJobs = {};
 
 // Import cron tasks
-cronJobs.timeout = require('./admin-commands/utilities/check-timeout');
+cronJobs.timeout = require('./cronjobs/check-timeout');
 
 // Cron
 cron.schedule('*/5 * * * *', function() {
@@ -107,64 +103,88 @@ bot.on('ready', () => {
 });
 
 function messageHandler(message) {
-  if (message.author.bot) // Ignore bot messages
+  // Ignore bot messages
+  if (message.author.bot) {
     return;
+  }
 
-  if (message.content[0] !== '!') // Commands start with '!'
+  // Commands start with '!'
+  if (message.content[0] !== '!') {
     return;
+  }
 
-  let commandText = message.content.split(' ')[0].substring(1);
+  const commandText = message.content.split(' ')[0].substring(1).toLowerCase();
+  const command = commands[commandText];
 
-  let command = commands[commandText.toLowerCase()];
-
-  // Admin/Mod check
-  let permission = false;
-  let adminCommand = false;
+  // Check that the command exists
+  if (!command) {
+    return;
+  }
 
   // If a command isn't allowed in a DM (or doesn't have allowDM defined),
   // make sure we're in a guild.
-  if (command && !command.allowDM && !message.guild) {
+  if (!command.allowDM && !message.guild) {
     message.reply('Sorry, I can only do that on a server. :frowning2:');
     return;
   }
 
-  // If we're in a guild, check for admin/mod. If not (ie DM), assume
-  // they're a normal user. This allows some commands to be run outside of
-  // a guild context.
-  //
-  // TODO: There's a hacky way round this but I'm not sure if I want to?
+  // Check that the user is allowed to use the bot (not necessary
+  // outside of a guild)
   if (message.guild) {
-    const adminRole = message.guild.roles.find('name', 'Admin');
-    const moderatorRole = message.guild.roles.find('name', 'Moderator');
-    let author = message.guild.member(message.author);
+    let shouldIgnoreMessage = true;
 
-    for (let [id, currentRole] of author.roles) {
-      if (currentRole === adminRole || currentRole === moderatorRole ||
-          message.author.id === '120897878347481088') {
-        permission = true;
+    // Check that the bot has any required roles at all
+    if (roles.REQUIRED_TO_USE_BOT.length > 0) {
+      // Try to find a common role between the required list and the
+      // user's roles
+      roles.REQUIRED_TO_USE_BOT.forEach((requiredRole) => {
+        if (message.member.roles.findKey('name', requiredRole)) {
+          shouldIgnoreMessage = false;
+        }
+      });
+    } else {
+      shouldIgnoreMessage = false;
+    }
+
+    // Check that the user is not part of a role that is banned from bot usage
+    roles.BANNED_FROM_BOT.forEach((bannedRole) => {
+      if (message.member.roles.findKey('name', bannedRole)) {
+        shouldIgnoreMessage = true;
       }
+    });
+
+    if (shouldIgnoreMessage) {
+      return;
     }
   }
 
-  // If command is not a regular command, check if it's an admin command
-  if (!command && permission) {
-    command = adminCommands[commandText.toLowerCase()];
-    if (adminCommands[commandText.toLowerCase()])
-      adminCommand = true;
+  // If the command requires roles, check that the user has one of them
+  if (command.requireRoles) {
+    // A command can't require roles and support DMs.
+    // This is a programmer error.
+    if (!message.guild) {
+      // TODO: Programmer error
+      return;
+    }
+
+    let satisfiesRoles = false;
+
+    // Loop through the roles needed by the command and see if the user
+    // has any of them.
+    command.requireRoles.forEach((role) => {
+      if (message.member.roles.findKey('name', role)) {
+        satisfiesRoles = true;
+      }
+    });
+
+    if (!satisfiesRoles) {
+      message.channel.sendMessage('I\'m sorry ' + message.author + ', I\'m ' +
+        'afraid I can\'t do that.');
+      return;
+    }
   }
 
-  // Admin only command but no permission
-  if (adminCommand && !permission) {
-    message.reply('naughty naughty... :wink: Only Admins and Moderators ' +
-        'can use the `!' + commandText + '` command.');
-    return;
-  }
-
-  // If we couldn't find any command, cut out
-  if (!command)
-    return;
-
-  command.process(bot, message, permission);
+  command.process(bot, message);
 }
 
 // Handle messages

--- a/roles.js
+++ b/roles.js
@@ -31,5 +31,17 @@ module.exports = {
     'Bot Commander',
     'Mee6',
     'Member'
+  ],
+
+  // A user must have one of these roles to use the bot (unless in a DM)
+  REQUIRED_TO_USE_BOT: [
+    'Member'
+  ],
+
+  // A user with any of these roles will have their messages ignored by the bot
+  // (unless in a DM). This ban supersedes the REQUIRED_TO_USE_BOT check.
+  BANNED_FROM_BOT: [
+    'Bot Restricted',
+    'Restricted'
   ]
 }


### PR DESCRIPTION
This PR adds two new fields to commands, `allowDM` and `requireRoles`.

If `allowDM` is true, a command can be run in a DM. Otherwise, the user is told that they need to run the command on a server.

If `requireRoles` is set on a command, the user must have a role in the list in order to run the command.

This PR also adds a list of roles required to use the bot at all, `REQUIRED_TO_USE_BOT`. If this is not empty, the user must have a role in the list in order to have their commands processed by the bot. Setting the list to empty disables this feature.

Lastly, a list of roles banned from bot usage is defined, `BANNED_FROM_BOT`. If a user has a role in this list, their commands are ignored by the bot. This supersedes the `REQUIRED_TO_USE_BOT` check.