### PR TITLE
Check that !timeout has a target

### DIFF
--- a/admin-commands/timeout.js
+++ b/admin-commands/timeout.js
@@ -16,6 +16,11 @@ module.exports = {
     // Updates to be pushed to firebase
     let updates = {};
 
+    if (!message.mentions.users.first()) {
+      message.reply('Usage: !timeout ' + module.exports.usage);
+      return;
+    }
+
     for (var [id, user] of message.mentions.users) {
 
       let member = message.guild.member(user);


### PR DESCRIPTION
Make sure that !timeout has a target. Previously it would respond with the success message sans any names.

Fixes gaymers-discord/DiscoBot#135