### PR TITLE
Delete message in #welcome-room when a user leaves

### DIFF
--- a/events/memberLeft.js
+++ b/events/memberLeft.js
@@ -4,11 +4,37 @@ const format = require('../momentFormat');
 module.exports = {
   // Logs a member leaving in #user-logs.
   process: (bot, guild, member) => {
-    let userLogs = bot.channels.find('name', 'user-logs');
+    const userLogs = bot.channels.find('name', 'user-logs');
+    const welcomeRoom = bot.channels.find('name', 'welcome-room');
 
     userLogs.sendMessage(
       member + ' left the server.' +
       ' (' + moment(Date.now()).format(format) + ')'
     );
+
+    // Attempt to find a welcome message for this user in the #welcome-room
+    // If one is found within the last 100 messages, delete it. This will also
+    // delete any other messages the bot made that mention this user, but
+    // that's probably not that big of a concern.
+    welcomeRoom.fetchMessages({limit: 100}).then((messages) => {
+      messages.forEach((message) => {
+        if (message.author.id !== bot.user.id) {
+          return;
+        }
+
+        const firstMention = message.mentions.users.first();
+        if (!firstMention) {
+          return;
+        }
+
+        if (firstMention.id === member.id) {
+          message.delete()
+            .catch(console.error);
+        }
+      })
+    },
+    (_) => {
+      // If this fails, it's no big deal.
+    });
   }
 };


### PR DESCRIPTION
This commit adds code to the leave handler that looks at the past 100 messages in #welcome-room and deletes messages that the bot sent that mention the leaving user. This is intended to delete the welcome message but as a side effect will also delete any other message that mentions the user (eg a `!slap` response). I don't think this is a big deal.