### PR TITLE
Change role-related commands to use promises

### DIFF
--- a/commands/role.js
+++ b/commands/role.js
@@ -52,47 +52,56 @@ module.exports = {
       return;
     }
 
+    const targetRole = message.guild.roles.find('name', roleName);
+
     // Make sure the role actually exists
-    if (!message.guild.roles.find('name', roleName)) {
+    if (!targetRole) {
       message.reply('Sorry... That\'s not a role :sob:');
       return;
     }
 
-    const targetRole = message.guild.roles.find('name', roleName);
-    const member = message.guild.member(message.author);
-    const newRoles = [];
-
-    // TODO: If we're removing a role and the user doesn't have the role, let
-    // them know that what they're doing doesn't make sense.
-
-    // Rebuild the user's role list into newRoles
-    for (let [id, role] of member.roles) {
-      if (targetRole === role) {
-        if (operator === 'add' || operator === 'set') {
-          message.reply('You already have the ' + role.name +
-              ' role? :confounded:');
-          return;
-        } else {
-          // We're removing this role, and we'll just leave it out
-        }
-      } else {
-        newRoles.push(role);
+    if (operator === 'add' || operator === 'set') {
+      // Check if they already have the role
+      if (message.member.roles.findKey('id', targetRole.id)) {
+        message.reply('You already have that role? :confused:');
+        return;
       }
-    }
 
-    // If adding a new role, add it on to the new roles list
-    if (operator === 'add' || operator === 'set') {
-      newRoles.push(targetRole);
-    }
+      // Add the new role
+      message.member.addRole(targetRole)
+        .then(
+          () => {
+            message.reply('I\'ve added your new role! :ok_hand:');
+          },
+          (rejectReason) => {
+            // TODO: Reject handler
+            console.error(rejectReason);
+          })
+        .catch((e) => {
+          // TODO: Error handler
+          console.error(e.stack);
+        });
+    } else if (operator === 'remove' || operator === 'unset') {
+      // Check if they have the role in the first place
+      if (!message.member.roles.findKey('id', targetRole.id)) {
+        message.reply('You don\'t have that role? :confused:');
+        return;
+      }
 
-    // ...and apply!
-    member.setRoles(newRoles);
-
-    // Give the user the appropriate feedback message
-    if (operator === 'add' || operator === 'set') {
-      message.reply('I\'ve added your new role! :ok_hand:');
-    } else {
-      message.reply('I\'ve removed that role from you! :ok_hand:');
+      // Remove the role
+      message.member.removeRole(targetRole)
+        .then(
+          () => {
+            message.reply('I\'ve removed that role from you! :ok_hand:');
+          },
+          (rejectReason) => {
+            // TODO: Reject handler
+            console.error(rejectReason);
+          })
+        .catch((e) => {
+          // TODO: Error handler
+          console.error(e.stack);
+        });
     }
   }
 };

--- a/commands/set18.js
+++ b/commands/set18.js
@@ -1,36 +1,31 @@
 module.exports = {
   usage: '',
-  description: 'Gives you the 18+ role, allows access to #over-18 and #over-18-text.',
+  description: 'Gives you the 18+ role, allows access to #over-18 ' +
+  'and #over-18-text.',
   allowDM: false,
   process: (bot, message) => {
-    let role = message.guild.roles.find('name', '18+');
-    let under18 = message.guild.roles.find('name', 'Under 18');
-    let member = message.guild.member(message.author);
-    let currentRoles = [];
-
-    for (var [id, currentRole] of member.roles) {
-
-      // Check if new region is already set on member
-      if (currentRole === role) {
-        message.reply('you\'ve already been set to ' + role.name);
-        return;
-      }
-
-      // Check if member has under18 role.
-      if (currentRole === under18){
-      	message.reply('You are under 18 years of age. I cannot add the 18+ role. :frowning: ');
-      	return;
-      }
-
-      currentRoles.push(currentRole);
+    if (message.member.roles.findKey('name', 'Under 18')) {
+      message.reply('You\'re under 18. I can\'t add the 18+ role. :frowning: ');
+      return;
     }
 
-    // Add the new region to the array
-    currentRoles.push(role);
+    if (message.member.roles.findKey('name', '18+')) {
+      message.reply('You already have 18+ set? :confused:');
+      return;
+    }
 
-    // Reapply the roles!
-    member.setRoles(currentRoles);
-
-    message.reply('I\'ve set you to ' + role.name + ' :wink:');
+    message.member.addRole(message.guild.roles.findKey('name', '18+'))
+      .then(
+        () => {
+          message.reply('I\'ve set you to 18+ :eggplant::peach:');
+        },
+        (rejectReason) => {
+          // TODO: Reject handler
+          console.error(rejectReason);
+        })
+      .catch((e) => {
+        // TODO: Error handler
+        console.error(e.stack);
+      });
   }
 };

--- a/commands/unset18.js
+++ b/commands/unset18.js
@@ -3,22 +3,24 @@ module.exports = {
   description: 'Removes the 18+ role.',
   allowDM: false,
   process: (bot, message) => {
-    let member = message.guild.member(message.author);
-    let role = message.guild.roles.find('name', '18+');
-    let currentRoles = [];
-
-    for (var [id, currentRole] of member.roles) {
-
-      // Check for region roles and ignore
-      if (currentRole !== role) {
-        currentRoles.push(currentRole);
-      }
+    if (!message.member.roles.findKey('name', '18+')) {
+      message.reply('You\'re not set as 18+? :confused:');
+      return;
     }
 
-    // Reapply the roles!
-    member.setRoles(currentRoles);
-
-    message.reply('I\'ve removed you from 18+ channels :smile:');
-
+    message.member.removeRole(message.guild.roles.findKey('name', '18+'))
+      .then(
+        () => {
+          message.reply('I\'ve removed your 18+ status' +
+          ':no_entry_sign::eggplant::peach:');
+        },
+        (rejectReason) => {
+          // TODO: Reject handler
+          console.error(rejectReason);
+        })
+      .catch((e) => {
+        // TODO: Error handler
+        console.error(e.stack);
+      });
   }
 };

--- a/commands/unsetregion.js
+++ b/commands/unsetregion.js
@@ -1,23 +1,33 @@
+const REGION_ROLES = require('../roles').REGION_ROLES;
+
 module.exports = {
   usage: '',
   description: 'Remove your region, remain mysterious.',
   allowDM: false,
   process: (bot, message) => {
-    let member = message.guild.member(message.author);
-    let currentRoles = [];
-
-    for (var [id, currentRole] of member.roles) {
-
-      // Check for region roles and ignore
-      if (!currentRole.name.match(/^(North America|South America|Middle East|Oceania|Europe|Africa|Asia)$/gi)) {
-        currentRoles.push(currentRole);
+    // Assemble a list of role IDs to give the removeRoles function, this
+    // does all of the removal in one shot.
+    const rolesToRemove = [];
+    REGION_ROLES.forEach((region) => {
+      const roleId = message.guild.roles.findKey('name', region);
+      if (roleId) {
+        rolesToRemove.push(roleId);
+      } else {
+        // FIXME: Warn about invalid region in list
       }
-    }
-
-    // Reapply the roles!
-    member.setRoles(currentRoles);
-
-    message.reply('I\'ve removed your region :smile:');
-
+    });
+    message.member.removeRoles(rolesToRemove)
+      .then(
+        () => {
+          message.reply('I\'ve removed your region :no_entry_sign::map:');
+        },
+        (rejectReason) => {
+          // TODO: Reject handler
+          console.error(rejectReason);
+        })
+      .catch((e) => {
+        // TODO: Error handler
+        console.error(e.stack);
+      });
   }
 };


### PR DESCRIPTION
Previously if one of these commands failed, the promise failure wouldn't be handled. This also changes the dirty role-list reassembly logic in these to use the simpler `addRole` and `removeRole` functions available on a GuildMember.

Fixes gaymers-discord/DiscoBot#108