### PR TITLE
Add Mee6 reward roles to blacklist

### DIFF
--- a/roles.js
+++ b/roles.js
@@ -30,6 +30,8 @@ module.exports = {
     'Push-to-talk',
     'Bot Commander',
     'Mee6',
+    'Keyboard Warrior',
+    'Keyboard GOD!',
     'Member'
   ],
 

--- a/roles.js
+++ b/roles.js
@@ -7,32 +7,32 @@ module.exports = {
     'Asia',
     'Europe',
     'Middle East',
-    'Oceania',
     'North America',
+    'Oceania',
     'South America'
   ],
 
   // Roles that cannot be managed with !role
   RESTRICTED_ROLES: [
+    '18+',
     'Admin',
-    'Moderator',
-    'Bots',
+    'Bot Commander',
     'Bot Developer',
-    'Restricted',
     'Bot Restricted',
-    'No links/files',
-    'Under 18',
+    'Bots',
     'DJ',
+    'DiscoBot',
     'ErisBot',
     'Event Manager',
-    'DiscoBot',
-    '18+',
-    'Push-to-talk',
-    'Bot Commander',
-    'Mee6',
-    'Keyboard Warrior',
     'Keyboard GOD!',
-    'Member'
+    'Keyboard Warrior',
+    'Mee6',
+    'Member',
+    'Moderator',
+    'No links/files',
+    'Push-to-talk',
+    'Restricted',
+    'Under 18'
   ],
 
   // A user must have one of these roles to use the bot (unless in a DM)


### PR DESCRIPTION
These are reward roles for Mee6 and shouldn't be managed by the bot.