### PR TITLE
Add check that we have enough args for !role

### DIFF
--- a/commands/role.js
+++ b/commands/role.js
@@ -15,6 +15,12 @@ module.exports = {
     // Split the message into command arguments on spaces
     msg = msg.split(' ');
 
+    // Check that we have at least '!role' 'add|remove|(etc)' and a role
+    if (msg.length < 3) {
+      message.reply('Usage: `!role ' + module.exports.usage + '`');
+      return;
+    }
+
     // Remove the first element, as it will be '!role'
     msg.shift();
 


### PR DESCRIPTION
Previously the .shift() calls in this command would raise an exception if a user entered only the command and no args (ie `!role`).