### PR TITLE
Change moment format to include year and TZ

### DIFF
--- a/momentFormat.js
+++ b/momentFormat.js
@@ -1,1 +1,1 @@
-module.exports = 'dddd, MMMM Do, HH:mm';
+module.exports = 'dddd, MMMM Do YYYY, HH:mm Z';


### PR DESCRIPTION
As discussed, this creates format strings like `Monday, December 19th 2016, 19:40 -08:00`.