### PR TITLE
Add `onlyIn` option to commands

### DIFF
--- a/commands/regions.js
+++ b/commands/regions.js
@@ -2,6 +2,7 @@ module.exports = {
   usage: '',
   description: 'Lists all available regions for use with the !setregion command.',
   allowDM: true,
+  onlyIn: ['bot-room'],
   process: (bot, message) => {
     message.reply(
       'To set your region type `!setregion [Your region]` in any channel. \n' +

--- a/commands/role.js
+++ b/commands/role.js
@@ -4,6 +4,7 @@ module.exports = {
   usage: 'add/remove [role]',
   description: 'Set or remove a role from yourself.',
   allowDM: false,
+  onlyIn: ['bot-room'],
   process: (bot, message) => {
     let msg = message.content;
 

--- a/commands/set18.js
+++ b/commands/set18.js
@@ -3,6 +3,7 @@ module.exports = {
   description: 'Gives you the 18+ role, allows access to #over-18 ' +
   'and #over-18-text.',
   allowDM: false,
+  onlyIn: ['bot-room'],
   process: (bot, message) => {
     if (message.member.roles.findKey('name', 'Under 18')) {
       message.reply('You\'re under 18. I can\'t add the 18+ role. :frowning: ');

--- a/commands/setregion.js
+++ b/commands/setregion.js
@@ -4,6 +4,7 @@ module.exports = {
   usage: '[your region]',
   description: 'Set your region, get pretty color.',
   allowDM: false,
+  onlyIn: ['bot-room'],
   process: (bot, message) => {
     let msg = message.content.split(' ');
 

--- a/commands/unset18.js
+++ b/commands/unset18.js
@@ -2,6 +2,7 @@ module.exports = {
   usage: '',
   description: 'Removes the 18+ role.',
   allowDM: false,
+  onlyIn: ['bot-room'],
   process: (bot, message) => {
     if (!message.member.roles.findKey('name', '18+')) {
       message.reply('You\'re not set as 18+? :confused:');

--- a/commands/unsetregion.js
+++ b/commands/unsetregion.js
@@ -4,6 +4,7 @@ module.exports = {
   usage: '',
   description: 'Remove your region, remain mysterious.',
   allowDM: false,
+  onlyIn: ['bot-room'],
   process: (bot, message) => {
     // Assemble a list of role IDs to give the removeRoles function, this
     // does all of the removal in one shot.

--- a/index.js
+++ b/index.js
@@ -99,6 +99,58 @@ bot.on('ready', () => {
   console.log('Bot ready!');
 });
 
+/**
+ * Return `true` if the command is allowed in this channel, `false` if not.
+ * Will DM the user and delete the message if not.
+ *
+ * @param command
+ * @param message
+ * @returns {boolean}
+ */
+function commandValidInChannel(command, message) {
+  if (command.onlyIn.includes(message.channel.name)) {
+    return true;
+  }
+
+  // Complain to the user about their mistake
+  const validChannels = [];
+  command.onlyIn.forEach(channelName => {
+    const channel = message.guild.channels.find('name', channelName);
+    // If that channel doesn't exist on this server, leave it out
+    if (!channel) {
+      return;
+    }
+
+    // If the user can't read messages in that channel, leave it out
+    if (!channel.permissionsFor(message.member)
+        .hasPermission('READ_MESSAGES')) {
+      return;
+    }
+
+    validChannels.push('`' + channelName + '`');
+  });
+
+  if (validChannels.length === 0) {
+    message.member.sendMessage('Sorry, that command can\'t be used in ' +
+      'that channel.');
+  } else if (validChannels.length === 1) {
+    message.member.sendMessage('Sorry, that command can only be used ' +
+      'in ' + validChannels[0] + '.');
+  } else {
+    message.member.sendMessage('Sorry, that command can only be used in ' +
+      'the following channels: ' + validChannels.join(', ') + '.');
+  }
+
+  // Remove the problem message
+  message.delete()
+    .catch(reason => {
+      // TODO Error handler
+      console.error(reason);
+    });
+
+  return false;
+}
+
 function messageHandler(message) {
   // Ignore bot messages
   if (message.author.bot) {
@@ -125,9 +177,17 @@ function messageHandler(message) {
     return;
   }
 
-  // Check that the user is allowed to use the bot (not necessary
-  // outside of a guild)
+  // Checks that are only needed on a server
   if (message.guild) {
+    // If the command can only be used in certain channels, check that we're in
+    // one of those channels
+    if (command.onlyIn && command.onlyIn.length > 0) {
+      if (!commandValidInChannel(command, message)) {
+        return;
+      }
+    }
+
+    // Check that the user is allowed to use the bot
     let shouldIgnoreMessage = true;
 
     // Check that the bot has any required roles at all


### PR DESCRIPTION
Setting this on a command will only allow it to be used in a channel by that name. If `allowDM` is set, it can also be used in a DM.

If this option is set and a user uses the command outside of its restricted channel, the bot will delete the message and DM the user a list of channels that the command may be used in. If the user does not have 'READ_MESSAGES' permission in the channel, the user will not be told about the channel. If no channels are valid for a user or server, the bot will just say that the "command isn't valid in that channel".

This also sets the following commands to only be valid in the `bot-room` channel:
- `!regions`
- `!role`
- `!set18`
- `!setregion`
- `!unset18`
- `!unsetregion`

This leaves the following commands to be valid everywhere:
- `!avatar`
- `!boop`
- `!cat`
- `!choose`
- `!help`
- `!hug`
- `!joined`
- `!magic8ball`
- `!penguin`
- `!slap`
- `!spray`
- `!timeout`

Thoughts on this list of commands?