### PR TITLE
Fix !joined giving an incorrect date with discord.js 10

### DIFF
--- a/commands/joined.js
+++ b/commands/joined.js
@@ -17,7 +17,7 @@ module.exports = {
         return;
       }
 
-      let joinDate = moment(message.guild.member(user).joinDate);
+      let joinDate = moment(message.guild.member(user).joinedAt);
 
       message.channel.sendMessage(user.toString() + ' joined ' + joinDate.fromNow() + ' (' + joinDate.format(format) + ')');
     }

--- a/commands/joined.js
+++ b/commands/joined.js
@@ -1,25 +1,33 @@
 const moment = require('moment');
 const format = require('../momentFormat');
 
+// For the special little snowflake...
+const REYNBOW = {
+  'id': '123395731548536832',
+  'joinedAt': moment('2015-12-27T01:00:00Z'),
+  'message': '{{USER}} BOUNCED IN HERE LIKE A FEISTY \'ROO ABOUT ' +
+      '{{DURATION}} ({{TIMESTAMP}}), MATE.'
+}
+
 module.exports = {
   usage: '[@user]',
   description: 'See when someone joined the server.',
   allowDM: false,
   process: (bot, message) => {
-    for (var [id, user] of message.mentions.users) {
-
-      if (id === '123395731548536832') { // If Reynbow.
-
-        var dr = moment('2015-12-27 01:00');
-        var now = dr.fromNow().toUpperCase();
-        message.channel.sendMessage(user.toString() + ' BOUNCED IN HERE LIKE A FEISTY \'ROO ABOUT ' + now + ' (' + dr.format(format).toUpperCase() + '), MATE.');
-
+    message.mentions.users.forEach(user => {
+      // Handle the snowflake case
+      if (user.id === REYNBOW.id) {
+        let reply = REYNBOW.message
+          .replace('{{USER}}', user)
+          .replace('{{DURATION}}', REYNBOW.joinedAt.fromNow())
+          .replace('{{TIMESTAMP}}', REYNBOW.joinedAt.format(format));
+        message.channel.sendMessage(reply.toUpperCase());
         return;
       }
 
-      let joinDate = moment(message.guild.member(user).joinedAt);
-
-      message.channel.sendMessage(user.toString() + ' joined ' + joinDate.fromNow() + ' (' + joinDate.format(format) + ')');
-    }
+      const joined = moment(message.guild.member(user).joinedAt);
+      message.channel.sendMessage(user + ' joined ' + joined.fromNow() +
+          ' (' + joined.format(format) + ')');
+    });
   }
 };


### PR DESCRIPTION
This changes the `!joined` command to use the `GuildMember.joinedAt` member instead of the undocumented(?) `GuildMember.joinDate` member.

This also includes a commit to clean up the `!joined` command.

Fixes gaymers-discord/DiscoBot#161