### PR TITLE
Remove 'Member' role when a user is timed out

### DIFF
--- a/commands/timeout.js
+++ b/commands/timeout.js
@@ -14,6 +14,7 @@ module.exports = {
 
     const restrictedRole = message.guild.roles.find('name', 'Restricted');
     const over18Role = message.guild.roles.find('name', '18+');
+    const memberRole = message.guild.roles.find('name', 'Member');
 
     // Updates to be pushed to firebase
     let updates = {};
@@ -33,6 +34,12 @@ module.exports = {
 
         // Check for 18+ role
         if (currentRole === over18Role) {
+          continue;
+        }
+
+        // Leave out the Member role since this makes the restriction to
+        // #appeals not work.
+        if (currentRole === memberRole) {
           continue;
         }
 

--- a/events/memberUpdated.js
+++ b/events/memberUpdated.js
@@ -24,6 +24,26 @@ function usernameUpdate(bot, oldMember, newMember) {
   );
 }
 
+function memberRestricted(member) {
+  // Remove the 'Member' role if someone gains the 'Restricted' role.
+  // This is needed because in Discord an 'ALLOW' permission takes precedence
+  // over a 'DENY' permission, which results in the 'ALLOW's from 'Member'
+  // keeping 'Restricted' from working.
+  const memberRole = member.guild.roles.find('name', 'Member');
+  member.removeRole(memberRole)
+    .then(
+        () => {},
+        reason => {
+          // TODO Rejection handler
+          console.error(reason);
+        }
+    )
+    .catch(e => {
+      // TODO Error handler
+      console.error(e);
+    });
+}
+
 function memberRoleAdded(newMember) {
   const generalChannel = newMember.guild.channels.find('name', 'general');
   const userLogsChannel = newMember.guild.channels.find('name', 'user-logs');
@@ -64,6 +84,12 @@ module.exports = {
     //if (oldMember.nickname !== newMember.nickname) {
     //  usernameUpdate(bot, oldMember, newMember);
     //}
+
+    // User gained the 'Restricted' role
+    if (!oldMember.roles.findKey('name', 'Restricted') &&
+          newMember.roles.findKey('name', 'Restricted')) {
+      memberRestricted(newMember);
+    }
 
     // User became a member
     if (!oldMember.roles.findKey('name', 'Member') &&


### PR DESCRIPTION
Because 'ALLOW' trumps 'DENY' in Discord, we need to remove the user's membership in order for 'Restricted' to take effect.

This is only a partial fix, we still need to be able to handle giving the user back their membership after their restriction is over.

This is a partial fix for gaymers-discord/DiscoBot#152