### PR TITLE
Custom timeout length 🎉

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ Requirements
 
 - node.js
 - Discord Bot Account
-- Firebase Database
 
 Running
 -------
@@ -51,19 +50,5 @@ bot locally. You can create one of these
 [here](https://discordapp.com/developers/applications/me). The application must
 be created as a 'Bot User' and invited to your test server following the
 instructions in the Discord docs.
-
-You will also need to set the following Firebase environment variables in
-order to test saving to the database.
-```
-  FIREBASE_API
-  FIREBASE_AUTH_DOMAIN
-  FIREBASE_DATABASE_URL
-  FIREBASE_STORAGE_BUCKET
-```
-These can be generated from the
-[Firebase console](https://console.firebase.google.com/).
-
-Finally, you can set the `APP_DEBUG` environment variable to `'true'` to
-ensure you get a few extra logging messages to the console.
 
 After adding these, run `npm start` to run the bot.

--- a/commands/choose.js
+++ b/commands/choose.js
@@ -1,7 +1,7 @@
 const splitargs = require('splitargs');
 
 module.exports = {
-  usage: '[Option 1] [Option 2] [etc]',
+  usage: '["Option 1"] ["Option 2"] etc',
   description: 'Let DiscoBot choose for you.',
   allowDM: true,
   process: (bot, message) => {
@@ -19,9 +19,9 @@ module.exports = {
     let choices = splitargs(message.content);
     choices.shift();
 
-    let choice = choices[Math.floor(Math.random() * choices.length)];
+    let choice = choices.random();
 
-    let response = responses[Math.floor(Math.random() * responses.length)];
+    let response = responses.random();
 
     message.reply(response.replace('%', choice));
   }

--- a/commands/timeout.js
+++ b/commands/timeout.js
@@ -1,20 +1,32 @@
+const Discord = require('discord.js');
 const firebase = require('firebase');
-const moment = require('moment');
-const format = require('../momentFormat');
+const splitargs = require('splitargs');
+const juration = require('juration');
 
 module.exports = {
-  usage: '[@user]',
+  usage: '[@user] [30m]',
   description: 'ADMIN ONLY: Give a user the \'Restricted\' role for 30 minutes. Will also remove the \'18+\' role.',
   allowDM: false,
   requireRoles: ['Admin', 'Moderator'],
   process: (bot, message) => {
-    let timeoutEnd = Date.now() + 1800000;
-
-    const userLogs = bot.channels.find('name', 'user-logs');
+    const userLogsChannel = bot.channels.find('name', 'user-logs');
 
     const restrictedRole = message.guild.roles.find('name', 'Restricted');
     const over18Role = message.guild.roles.find('name', '18+');
     const memberRole = message.guild.roles.find('name', 'Member');
+
+    // Calculate the end time
+    const timeoutStart = Date.now();
+
+    // Let's grab just the time...
+    let timeoutLengthArray = splitargs(message.content);
+    timeoutLengthArray.shift();
+    timeoutLengthArray.shift();
+    let timeoutLength = timeoutLengthArray[0];
+
+    if (!timeoutLength) timeoutLength = '30m';
+
+    const timeoutEnd = timeoutStart + juration.parse(timeoutLength) * 1000;
 
     // Updates to be pushed to firebase
     let updates = {};
@@ -24,58 +36,52 @@ module.exports = {
       return;
     }
 
-    for (var [id, user] of message.mentions.users) {
+    let user = message.guild.member(message.mentions.users.first());
+    let currentRoles = [];
 
-      let member = message.guild.member(user);
-      let currentRoles = [];
+    // Iterate roles to remove 18+ and Member
+    for (let [id, currentRole] of user.roles) {
 
-      // Iterate roles
-      for (let [id, currentRole] of member.roles) {
-
-        // Check for 18+ role
-        if (currentRole === over18Role) {
-          continue;
-        }
-
-        // Leave out the Member role since this makes the restriction to
-        // #appeals not work.
-        if (currentRole === memberRole) {
-          continue;
-        }
-
-        currentRoles.push(currentRole);
+      // Check for 18+ role
+      if (currentRole === over18Role) {
+        continue;
       }
 
-      // Add restricted role
-      currentRoles.push(restrictedRole);
+      // Leave out the Member role since this makes the restriction to
+      // #appeals not work.
+      if (currentRole === memberRole) {
+        continue;
+      }
 
-      // Reapply the roles!
-      member.setRoles(currentRoles);
-
-      // Set timeout release time to now + 30 mins in ms
-      updates['/admin/timeout/' + user.id] = timeoutEnd;
+      currentRoles.push(currentRole);
     }
+
+    // Add restricted role
+    currentRoles.push(restrictedRole);
+
+    // Reapply the roles!
+    user.setRoles(currentRoles);
+
+    // Set timeout release time to now + 30 mins in ms
+    updates['/admin/timeout/' + user.id] = timeoutEnd;
 
     // Push updates to firebase
     firebase.database().ref().update(updates);
 
-    // Confirmation response
-    let response = '';
+    // Send a confirmation message to #user-logs
+    let embed = new Discord.RichEmbed();
 
-    let mentions = message.mentions.users.array();
+    embed.setColor(0xE67E21);
+    embed.setTitle('User Given Timeout');
+    embed.addField('User', user, true);
+    embed.addField('Timeout Length',
+      juration.stringify(juration.parse(timeoutLength)), true);
 
-    if (mentions.length === 1) {
-      response += mentions[0] + ' is';
-    } else {
-      for (let i = 0; i < mentions.length; i++) {
-        response += mentions[i] + ' ';
-      }
-      response += 'are';
-    }
+    embed.setFooter('Timeout End');
 
-    response += ' on a timeout for 30 minutes.';
-    message.reply(response);
+    let embedDate = new Date(timeoutEnd);
+    embed.setTimestamp(embedDate.toISOString());
 
-    userLogs.sendMessage(response + ' (' + moment(Date.now()).format(format) + ') until (' + moment(timeoutEnd).format(format) + ')');
+    userLogsChannel.sendMessage('', { embed: embed });
   }
 };

--- a/commands/timeout.js
+++ b/commands/timeout.js
@@ -19,12 +19,14 @@ module.exports = {
     const timeoutStart = Date.now();
 
     // Let's grab just the time...
-    let timeoutLengthArray = splitargs(message.content);
+    const timeoutLengthArray = splitargs(message.content);
     timeoutLengthArray.shift();
     timeoutLengthArray.shift();
     let timeoutLength = timeoutLengthArray[0];
 
-    if (!timeoutLength) timeoutLength = '30m';
+    if (!timeoutLength) {
+      timeoutLength = '30m';
+    }
 
     const timeoutEnd = timeoutStart + juration.parse(timeoutLength) * 1000;
 
@@ -36,7 +38,7 @@ module.exports = {
       return;
     }
 
-    let user = message.guild.member(message.mentions.users.first());
+    const user = message.guild.member(message.mentions.users.first());
     let currentRoles = [];
 
     // Iterate roles to remove 18+ and Member
@@ -69,7 +71,7 @@ module.exports = {
     firebase.database().ref().update(updates);
 
     // Send a confirmation message to #user-logs
-    let embed = new Discord.RichEmbed();
+    const embed = new Discord.RichEmbed();
 
     embed.setColor(0xE67E21);
     embed.setTitle('User Given Timeout');
@@ -79,8 +81,8 @@ module.exports = {
 
     embed.setFooter('Timeout End');
 
-    let embedDate = new Date(timeoutEnd);
-    embed.setTimestamp(embedDate.toISOString());
+    const embedDate = new Date(timeoutEnd).toISOString();
+    embed.setTimestamp(embedDate);
 
     userLogsChannel.sendMessage('', { embed: embed });
   }

--- a/commands/timeout.js
+++ b/commands/timeout.js
@@ -1,11 +1,11 @@
 const Discord = require('discord.js');
 const firebase = require('firebase');
 const splitargs = require('splitargs');
-const juration = require('juration');
+const Duration = require('duration-js');
 
 module.exports = {
   usage: '[@user] [30m]',
-  description: 'ADMIN ONLY: Give a user the \'Restricted\' role for 30 minutes. Will also remove the \'18+\' role.',
+  description: 'ADMIN ONLY: Give a user the \'Restricted\' role  (default: 30 minutes). Will also remove the \'18+\' and \'Member\' role.',
   allowDM: false,
   requireRoles: ['Admin', 'Moderator'],
   process: (bot, message) => {
@@ -22,13 +22,19 @@ module.exports = {
     const timeoutLengthArray = splitargs(message.content);
     timeoutLengthArray.shift();
     timeoutLengthArray.shift();
-    let timeoutLength = timeoutLengthArray[0];
+    let timeoutLength;
 
-    if (!timeoutLength) {
-      timeoutLength = '30m';
+    if (!timeoutLengthArray[0]) {
+      timeoutLength = new Duration('30m');
+    } else {
+      try {
+        timeoutLength = new Duration(timeoutLengthArray[0]);
+      } catch (error) {
+        timeoutLength = new Duration('30m');
+      }
     }
 
-    const timeoutEnd = timeoutStart + juration.parse(timeoutLength) * 1000;
+    const timeoutEnd = timeoutStart + timeoutLength;
 
     // Updates to be pushed to firebase
     let updates = {};
@@ -76,8 +82,7 @@ module.exports = {
     embed.setColor(0xE67E21);
     embed.setTitle('User Given Timeout');
     embed.addField('User', user, true);
-    embed.addField('Timeout Length',
-      juration.stringify(juration.parse(timeoutLength)), true);
+    embed.addField('Timeout Length', timeoutLength.toString(), true);
 
     embed.setFooter('Timeout End');
 

--- a/cronjobs/checkTimeout.js
+++ b/cronjobs/checkTimeout.js
@@ -21,8 +21,8 @@ module.exports = {
           // If timeout has expired
           if (expires < Date.now() && member) {
             let currentRoles = [];
-            let restrictedRole = guild.roles.find('name', 'Restricted');
-            let memberRole = guild.roles.find('name', 'Member');
+            const restrictedRole = guild.roles.find('name', 'Restricted');
+            const memberRole = guild.roles.find('name', 'Member');
 
             // Iterate roles
             for (let [id, currentRole] of member.roles) {
@@ -45,14 +45,14 @@ module.exports = {
             updates['/admin/timeout/' + user] = null;
 
             // Log removal in user-logs
-            let embed = new Discord.RichEmbed();
+            const embed = new Discord.RichEmbed();
 
             embed.setColor(0xE67E21);
             embed.setTitle('User Removed From Timeout');
             embed.addField('User', member, true);
 
-            let embedDate = new Date(Date.now());
-            embed.setTimestamp(embedDate.toISOString());
+            const embedDate = new Date(Date.now()).toISOString();
+            embed.setTimestamp(embedDate);
 
             userLogsChannel.sendMessage('', { embed: embed });
           }

--- a/cronjobs/checkTimeout.js
+++ b/cronjobs/checkTimeout.js
@@ -1,11 +1,10 @@
+const Discord = require('discord.js');
 const firebase = require('firebase');
-const moment = require('moment');
-const format = require('../momentFormat');
 
 module.exports = {
   process: (bot) => {
     const guild = bot.guilds.array()[0];
-    const userLogs = guild.channels.find('name', 'user-logs');
+    const userLogsChannel = guild.channels.find('name', 'user-logs');
 
     let getData = firebase.database().ref('/admin/timeout/');
 
@@ -23,6 +22,7 @@ module.exports = {
           if (expires < Date.now() && member) {
             let currentRoles = [];
             let restrictedRole = guild.roles.find('name', 'Restricted');
+            let memberRole = guild.roles.find('name', 'Member');
 
             // Iterate roles
             for (let [id, currentRole] of member.roles) {
@@ -35,6 +35,9 @@ module.exports = {
               currentRoles.push(currentRole);
             }
 
+            // Give them back the member role
+            currentRoles.push(memberRole);
+
             // Reapply the roles!
             member.setRoles(currentRoles);
 
@@ -42,7 +45,16 @@ module.exports = {
             updates['/admin/timeout/' + user] = null;
 
             // Log removal in user-logs
-            userLogs.sendMessage(member + ' has been removed from timeout. (' + moment(Date.now()).format(format) + ')');
+            let embed = new Discord.RichEmbed();
+
+            embed.setColor(0xE67E21);
+            embed.setTitle('User Removed From Timeout');
+            embed.addField('User', member, true);
+
+            let embedDate = new Date(Date.now());
+            embed.setTimestamp(embedDate.toISOString());
+
+            userLogsChannel.sendMessage('', { embed: embed });
           }
         }
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const cron = require('node-cron');
 const Discord = require('discord.js');
-const firebase = require('firebase');
+const AWS = require('aws-sdk');
 const moment = require('moment');
 
 const format = require('./momentFormat');
@@ -33,15 +33,11 @@ function cleanup() {
 process.on('SIGINT', cleanup);
 process.on('SIGTERM', cleanup);
 
-// Firebase
-const config = {
-  apiKey: process.env.FIREBASE_API,
-  authDomain: process.env.FIREBASE_AUTH_DOMAIN,
-  databaseURL: process.env.FIREBASE_DATABASE_URL,
-  storageBucket: process.env.FIREBASE_STORAGE_BUCKET
-};
-
-firebase.initializeApp(config);
+// AWS SDK
+AWS.config.update({
+  region: 'eu-west-1',
+  endpoint: 'dynamodb.eu-west-1.amazonaws.com'
+});
 
 // Commands
 const commands = {};

--- a/index.js
+++ b/index.js
@@ -84,7 +84,7 @@ events.messageUpdated = require('./events/messageUpdated');
 const cronJobs = {};
 
 // Import cron tasks
-cronJobs.timeout = require('./cronjobs/check-timeout');
+cronJobs.timeout = require('./cronjobs/checkTimeout');
 
 // Cron
 cron.schedule('*/5 * * * *', function() {

--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
   },
   "license": "GPL-2.0",
   "dependencies": {
+    "aws-sdk": "^2.9.0",
     "discord.js": "^11.0.0",
     "duration-js": "^3.9.2",
     "erlpack": "github:hammerandchisel/erlpack",
-    "firebase": "^3.3.0",
     "moment": "^2.13.0",
     "moment-timezone": "^0.5.4",
     "node-cron": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
   "license": "GPL-2.0",
   "dependencies": {
     "discord.js": "^11.0.0",
+    "duration-js": "^3.9.2",
     "erlpack": "github:hammerandchisel/erlpack",
     "firebase": "^3.3.0",
-    "juration": "0.0.1",
     "moment": "^2.13.0",
     "moment-timezone": "^0.5.4",
     "node-cron": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "discord.js": "^11.0.0",
     "erlpack": "github:hammerandchisel/erlpack",
     "firebase": "^3.3.0",
+    "juration": "0.0.1",
     "moment": "^2.13.0",
     "moment-timezone": "^0.5.4",
     "node-cron": "^1.1.2",


### PR DESCRIPTION
_Finally._

- Adds the ability to set a length of time (in the format `2h45m`).
- Defaults to 30 minutes
- Updates timeout related logs to new embeds
- `!choose` now uses the `.random()` array function from utils
- Now uses an AWS DynamoDB to store timeouts instead of firebase