### PR TITLE
Add !roles command to list available roles

### DIFF
--- a/commands/role.js
+++ b/commands/role.js
@@ -18,7 +18,8 @@ module.exports = {
 
     // Check that we have at least '!role' 'add|remove|(etc)' and a role
     if (msg.length < 3) {
-      message.reply('Usage: `!role ' + module.exports.usage + '`');
+      message.reply('Usage: `!role ' + module.exports.usage + '`' +
+        ' For a list of available roles use `!roles`');
       return;
     }
 

--- a/commands/roles.js
+++ b/commands/roles.js
@@ -1,0 +1,48 @@
+const roles = require('../roles');
+
+module.exports = {
+  usage: '',
+  description: 'List roles that can be added using the !role command.',
+  allowDM: false,
+  onlyIn: ['bot-room'],
+  process: (bot, message) => {
+    const guild = bot.guilds.first();
+    const serverRoles = guild.roles;
+
+    let availableRoles = [];
+
+    ServerRoleLoop:
+    for (let [id, role] of serverRoles) {
+      // Filter restricted roles
+      for (let restrictedRole of roles.RESTRICTED_ROLES) {
+        if (role.name == restrictedRole) {
+          continue ServerRoleLoop;
+        }
+      }
+
+      // Filter region roles
+      for (let restrictedRole of roles.REGION_ROLES) {
+        if (role.name == restrictedRole) {
+          continue ServerRoleLoop;
+        }
+      }
+
+      // Filter @everyone
+      if (role.name === '@everyone') {
+        continue ServerRoleLoop;
+      }
+
+      availableRoles.push(role);
+    }
+
+    let response = 'Here\'s the roles you can add:\n```';
+
+    for (let role of availableRoles) {
+      response += role.name + '\n';
+    }
+
+    response += '```';
+
+    message.reply(response);
+  }
+};

--- a/index.js
+++ b/index.js
@@ -56,6 +56,7 @@ commands.joined = require('./commands/joined');
 commands.magic8ball = require('./commands/magic8ball');
 commands.regions = require('./commands/regions');
 commands.role = require('./commands/role');
+commands.roles = require('./commands/roles');
 commands.set18 = require('./commands/set18');
 commands.setregion = require('./commands/setregion');
 commands.slap = require('./commands/slap');

--- a/roles.js
+++ b/roles.js
@@ -46,4 +46,4 @@ module.exports = {
     'Bot Restricted',
     'Restricted'
   ]
-}
+};


### PR DESCRIPTION
- Adds the `roles` command to list roles that people can add to themselves
- Updates the usage help of the `!role` command to include information about this

Completes gaymers-discord/DiscoBot#101