### PR TITLE
Self-targeting for !joined

### DIFF
--- a/commands/joined.js
+++ b/commands/joined.js
@@ -12,30 +12,26 @@ module.exports = {
   description: 'See when someone joined the server.',
   allowDM: false,
   process: (bot, message) => {
-    message.mentions.users.forEach(user => {
-      const member = message.guild.member(user);
-      let joined = moment(member.joinedAt);
+    let target = message.guild.member(message.mentions.users.first());
+    if (!target) {
+      target = message.member;
+    }
 
-      if (user.id === REYNBOW.id) {
-        joined = REYNBOW.joinedAt;
-      }
+    const embed = new Discord.RichEmbed();
+    embed.setColor(0x3398DB);
+    embed.addField('User', target);
 
-      const embed = new Discord.RichEmbed();
+    if (target.id === REYNBOW.id) {
+      embed.setTitle(target.displayName.toUpperCase() +
+        ' BOUNCED IN HERE LIKE A FEISTY \'ROO ABOUT ' +
+        moment(REYNBOW.joinedAt).fromNow().toUpperCase() + ', MATE.');
+      embed.setTimestamp(REYNBOW.joinedAt);
+    } else {
+      embed.setTitle(target.displayName + ' joined ' +
+        moment(target.joinedAt).fromNow());
+      embed.setTimestamp(target.joinedAt);
+    }
 
-      embed.setColor(0x3398DB);
-      embed.setTitle(member.displayName + ' joined ' + moment(joined).fromNow());
-
-      if (user.id === REYNBOW.id) {
-        embed.setTitle(member.displayName.toUpperCase() +
-          ' BOUNCED IN HERE LIKE A FEISTY \'ROO ABOUT ' +
-          moment(joined).fromNow().toUpperCase() + ', MATE.');
-      }
-
-      embed.addField('User', member);
-
-      embed.setTimestamp(joined);
-
-      message.channel.sendMessage('', { embed: embed });
-    });
+    message.channel.sendMessage('', { embed: embed });
   }
 };

--- a/commands/joined.js
+++ b/commands/joined.js
@@ -1,6 +1,5 @@
 const Discord = require('discord.js');
 const moment = require('moment');
-const format = require('../momentFormat');
 
 // For the special little snowflake...
 const REYNBOW = {


### PR DESCRIPTION
Allow the usage of !joined on its own to target the sender, like the recent change to !avatar