### PR TITLE
Move restricted users to AFK if they're in VC

### DIFF
--- a/events/memberUpdated.js
+++ b/events/memberUpdated.js
@@ -83,6 +83,22 @@ function memberRestricted(member) {
       // TODO Error handler
       console.error(e);
     });
+
+  // If the member is in a voice chat, move them to AFK
+  if (member.voiceChannel) {
+    const afkVoiceChannel = member.guild.channels.filter(value => {
+      return value.type === 'voice' && value.name === 'AFK';
+    });
+    if (!afkVoiceChannel.first()) {
+      // There isn't an AFK channel!? Deaf/mute the user.
+      member.setMute(true);
+      member.setDeaf(true);
+      console.error('There isn\'t an AFK voice channel!');
+      // TODO Error handler
+      return;
+    }
+    member.setVoiceChannel(afkVoiceChannel.first());
+  }
 }
 
 


### PR DESCRIPTION
Currently when members are in a voice chat and they become restricted, nothing happens to them. This will move them to AFK when they're restricted. As a fallback if the AFK channel can't be found (for some
reason), it will mute/deafen them.

Closes gaymers-discord/DiscoBot#202