### PR TITLE
Remove 'ADMIN ONLY' from command descriptions

### DIFF
--- a/commands/member.js
+++ b/commands/member.js
@@ -19,7 +19,7 @@
 
 module.exports = {
   usage: '[@user]',
-  description: 'ADMIN ONLY: Give a user the \'Member\' role.',
+  description: 'Give a user the \'Member\' role.',
   allowDM: false,
   requireRoles: ['Admin', 'Moderator'],
   process: (bot, message) => {

--- a/commands/status.js
+++ b/commands/status.js
@@ -21,7 +21,7 @@ const splitargs = require('splitargs');
 
 module.exports = {
   usage: 'Message to display,',
-  description: 'ADMIN ONLY: Set the status of the bot.',
+  description: 'Set the status of the bot.',
   allowDM: false,
   requireRoles: ['Admin', 'Moderator'],
   process: (bot, message) => {

--- a/commands/stream.js
+++ b/commands/stream.js
@@ -21,7 +21,7 @@ const splitargs = require('splitargs');
 
 module.exports = {
   usage: 'Message to display as a stream.',
-  description: 'ADMIN ONLY: Set the stream status of the bot.',
+  description: 'Set the stream status of the bot.',
   allowDM: false,
   requireRoles: ['Admin', 'Moderator'],
   process: (bot, message) => {


### PR DESCRIPTION
This isn't necessary because the staff commands are listed on their own in !help, and was actually incorrect because these commands could have also been used by moderators.