### PR TITLE
Simplified Region Role Handling

### DIFF
--- a/commands/setregion.js
+++ b/commands/setregion.js
@@ -60,49 +60,34 @@ module.exports = {
       return;
     }
 
-    const oldRegionRoles = message.member.roles.filter(function(existingRole) {
-      return REGIONS.includes(existingRole.name);
-    });
-
-    if (oldRegionRoles) {
-      oldRegionRoles.forEach(role => {
-        message.member.removeRole(role)
-          .catch((e) => {
-            // TODO: Error handler
-            console.error(e.stack);
-            message.reply('I couldn\'t change your previous region!');
-          });
+    // Remove all existing region roles from the user
+    message.member.removeRoles(REGIONS.reduce((acc, cur) => {
+      return acc.concat(message.guild.roles.find('name', cur));
+    }, []))
+      .then(() => {},
+        (rejectReason) => {
+          // TODO: Reject handler
+          console.error(rejectReason);
+        })
+      .catch((e) => {
+        // TODO: Error handler
+        console.error(e.stack);
       });
 
-      message.member.addRole(newRegionRole)
-        .then(() => {
-          message.reply('I\'ve set your region! :white_check_mark::map: ' +
-            'Check out `!role` for other roles you can add!');
-        },
-          (rejectReason) => {
-            // TODO: Reject handler
-            console.error(rejectReason);
-          })
-        .catch((e) => {
-          // TODO: Error handler
-          console.error(e.stack);
-          message.reply('I couldn\'t give you a new region!');
-        });
-    } else {
-      message.member.addRole(newRegionRole)
-        .then(() => {
-          message.reply('I\'ve set your region! :white_check_mark::map: ' +
-            'Check out `!role` for other roles you can add!');
-        },
-          (rejectReason) => {
-            // TODO: Reject handler
-            console.error(rejectReason);
-          })
-        .catch((e) => {
-          // TODO: Error handler
-          console.error(e.stack);
-          message.reply('I couldn\'t give you a new region!');
-        });
-    }
+    // Add the new region role
+    message.member.addRole(newRegionRole)
+      .then(() => {
+        message.reply('I\'ve set your region! :white_check_mark::map: ' +
+          'Check out `!role` for other roles you can add!');
+      },
+        (rejectReason) => {
+          // TODO: Reject handler
+          console.error(rejectReason);
+        })
+      .catch((e) => {
+        // TODO: Error handler
+        console.error(e.stack);
+        message.reply('I couldn\'t give you a new region! :sob:');
+      });
   }
 };

--- a/commands/setregion.js
+++ b/commands/setregion.js
@@ -60,17 +60,35 @@ module.exports = {
       return;
     }
 
-    const oldRegionRole = message.member.roles.find(function(existingRole) {
+    const oldRegionRoles = message.member.roles.filter(function(existingRole) {
       return REGIONS.includes(existingRole.name);
     });
 
-    if (oldRegionRole) {
-      message.member.removeRole(oldRegionRole)
-        .then(member => {
-          member.addRole(newRegionRole);
+    if (oldRegionRoles) {
+      oldRegionRoles.forEach(role => {
+        message.member.removeRole(role)
+          .catch(() => {
+            message.reply('I couldn\'t change your previous region!');
+          });
+      });
+
+      message.member.addRole(newRegionRole)
+        .then(() => {
+          message.reply('I\'ve set your region! :white_check_mark::map: ' +
+            'Check out `!role` for other roles you can add!');
+        })
+        .catch(() => {
+          message.reply('I couldn\'t give you a new region!');
         });
     } else {
-      message.member.addRole(newRegionRole);
+      message.member.addRole(newRegionRole)
+        .then(() => {
+          message.reply('I\'ve set your region! :white_check_mark::map: ' +
+            'Check out `!role` for other roles you can add!');
+        })
+        .catch(() => {
+          message.reply('I couldn\'t give you a new region!');
+        });
     }
   }
 };

--- a/commands/setregion.js
+++ b/commands/setregion.js
@@ -41,8 +41,8 @@ module.exports = {
     // If the user supplied a bad region name, give them the list
     if (!REGIONS.includes(regionName)) {
       message.reply('To set your region, type `!setregion ' +
-          module.exports.usage + '`\nHere\'s the regions I can give you: ' +
-          REGIONS.join(', '));
+        module.exports.usage + '`\nHere\'s the regions I can give you: ' +
+        REGIONS.join(', '));
       return;
     }
 
@@ -67,7 +67,9 @@ module.exports = {
     if (oldRegionRoles) {
       oldRegionRoles.forEach(role => {
         message.member.removeRole(role)
-          .catch(() => {
+          .catch((e) => {
+            // TODO: Error handler
+            console.error(e.stack);
             message.reply('I couldn\'t change your previous region!');
           });
       });
@@ -76,8 +78,14 @@ module.exports = {
         .then(() => {
           message.reply('I\'ve set your region! :white_check_mark::map: ' +
             'Check out `!role` for other roles you can add!');
-        })
-        .catch(() => {
+        },
+          (rejectReason) => {
+            // TODO: Reject handler
+            console.error(rejectReason);
+          })
+        .catch((e) => {
+          // TODO: Error handler
+          console.error(e.stack);
           message.reply('I couldn\'t give you a new region!');
         });
     } else {
@@ -85,8 +93,14 @@ module.exports = {
         .then(() => {
           message.reply('I\'ve set your region! :white_check_mark::map: ' +
             'Check out `!role` for other roles you can add!');
-        })
-        .catch(() => {
+        },
+          (rejectReason) => {
+            // TODO: Reject handler
+            console.error(rejectReason);
+          })
+        .catch((e) => {
+          // TODO: Error handler
+          console.error(e.stack);
           message.reply('I couldn\'t give you a new region!');
         });
     }

--- a/commands/setregion.js
+++ b/commands/setregion.js
@@ -60,34 +60,17 @@ module.exports = {
       return;
     }
 
-    // We need to rebuild the role list here because using removeRoles and
-    // addRoles shortly after each other seems to not work. It looks like
-    // role removal has no effect, even when put in removeRoles' .then()
-    // Hopefully I'll be able to debug this in the future and we can return
-    // to a simplified .removeRoles() .addRole() solution. JM
-    const modifiedRoleList = [];
-    message.member.roles.forEach(existingRole => {
-      if (REGIONS.includes(existingRole.name)) {
-        // Filter out any region roles
-        return;
-      }
-      modifiedRoleList.push(existingRole);
+    const oldRegionRole = message.member.roles.find(function(existingRole) {
+      return REGIONS.includes(existingRole.name);
     });
-    modifiedRoleList.push(newRegionRole);
 
-    message.member.setRoles(modifiedRoleList)
-      .then(
-        () => {
-          message.reply('I\'ve set your region! :white_check_mark::map: ' +
-            'Check out `!role` for other roles you can add!');
-        },
-        (rejectReason) => {
-          // TODO: Reject handler
-          console.error(rejectReason);
-        })
-      .catch((e) => {
-        // TODO: Error handler
-        console.error(e.stack);
-      });
+    if (oldRegionRole) {
+      message.member.removeRole(oldRegionRole)
+        .then(member => {
+          member.addRole(newRegionRole);
+        });
+    } else {
+      message.member.addRole(newRegionRole);
+    }
   }
 };

--- a/commands/unsetregion.js
+++ b/commands/unsetregion.js
@@ -17,7 +17,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  * */
 
-const REGION_ROLES = require('../roles').REGION_ROLES;
+const REGIONS = require('../roles').REGION_ROLES;
 
 module.exports = {
   usage: '',
@@ -25,22 +25,13 @@ module.exports = {
   allowDM: false,
   onlyIn: ['bot-room'],
   process: (bot, message) => {
-    // Assemble a list of role IDs to give the removeRoles function, this
-    // does all of the removal in one shot.
-    const rolesToRemove = [];
-    REGION_ROLES.forEach((region) => {
-      const roleId = message.guild.roles.findKey('name', region);
-      if (roleId) {
-        rolesToRemove.push(roleId);
-      } else {
-        // FIXME: Warn about invalid region in list
-      }
-    });
-    message.member.removeRoles(rolesToRemove)
-      .then(
-        () => {
+    // Remove all existing region roles from the user
+    message.member.removeRoles(REGIONS.reduce((acc, cur) => {
+      return acc.concat(message.guild.roles.find('name', cur));
+    }, []))
+      .then(() => {
           message.reply('I\'ve removed your region :no_entry_sign::map:');
-        },
+      },
         (rejectReason) => {
           // TODO: Reject handler
           console.error(rejectReason);


### PR DESCRIPTION
This achieves not having to rebuild the role list in order to add, then remove region roles. It also simplifies the process of removing all region roles in one shot.

This is based off of #261, props to @coderMess for his initial work on this and finding that the bug that was blocking this had been fixed.

This also fixes #244 (somehow 🤷‍♀️ ).