### PR TITLE
adds role seperation of welcome role

### DIFF
--- a/commands/member.js
+++ b/commands/member.js
@@ -29,7 +29,7 @@ module.exports = {
     }
 
     const member = message.guild.member(message.mentions.users.first());
-    const memberRole = message.guild.roles.find('name', 'Member');
+    const memberRole = message.guild.roles.find('name', 'Welcome');
 
     member.addRole(memberRole);
     message.channel.send(member + ' has been given the `Member` role. :ok_hand:');

--- a/events/memberUpdated.js
+++ b/events/memberUpdated.js
@@ -118,8 +118,8 @@ function welcomeRoleAdded(newMember) {
   const generalChannel = newMember.guild.channels.find('name', 'general');
   const userLogsChannel = newMember.guild.channels.find('name', 'user-logs');
 
-  welcomeRole = findRole(newMember.guild, 'Welcome');
-  memberRole = findRole(newMember.guild, 'Member');
+  welcomeRole =  newMember.guild.roles.find('name', 'Welcome');
+  memberRole =  newMember.guild.roles.find('name', 'Member');
 
   // Publicly welcome the user
   if (!generalChannel) {
@@ -160,14 +160,6 @@ function welcomeRoleAdded(newMember) {
 
   newMember.removeRole(welcomeRole);
   newMember.addRole(memberRole);
-}
-
-function findRole(guild, roleName) {
-  for (const role of guild.roles.array()) {
-    if (role.name.toLowerCase() === roleName.toLowerCase()) {
-      return role;
-    }
-  }
 }
 
 

--- a/events/memberUpdated.js
+++ b/events/memberUpdated.js
@@ -114,9 +114,12 @@ function memberRestricted(member) {
 
 
 
-function memberRoleAdded(newMember) {
+function welcomeRoleAdded(newMember) {
   const generalChannel = newMember.guild.channels.find('name', 'general');
   const userLogsChannel = newMember.guild.channels.find('name', 'user-logs');
+
+  welcomeRole = findRole(newMember.guild, 'Welcome');
+  memberRole = findRole(newMember.guild, 'Member');
 
   // Publicly welcome the user
   if (!generalChannel) {
@@ -154,8 +157,18 @@ function memberRoleAdded(newMember) {
     '**!setregion [region]** - Discobot will set your colour based on your region. For example `!setregion Europe` or `!setregion North America` \n' +
     '**!set18** - Discobot will give you access to the #over-18 channel. \n'
   );
+
+  newMember.removeRole(welcomeRole);
+  newMember.addRole(memberRole);
 }
 
+function findRole(guild, roleName) {
+  for (const role of guild.roles.array()) {
+    if (role.name.toLowerCase() === roleName.toLowerCase()) {
+      return role;
+    }
+  }
+}
 
 
 module.exports = {
@@ -174,9 +187,9 @@ module.exports = {
     }
 
     // User became a member
-    if (!oldMember.roles.findKey('name', 'Member') &&
-      newMember.roles.findKey('name', 'Member')) {
-      memberRoleAdded(newMember);
+    if (!oldMember.roles.findKey('name', 'Welcome') &&
+      newMember.roles.findKey('name', 'Welcome')) {
+      welcomeRoleAdded(newMember);
     }
   }
 };


### PR DESCRIPTION
Will require a new role added to the server - `welcome`, this role will require no privileges.

The flow of a user joining should now follow:

1. User given the `welcome` role either by the `!member` command or manually by a mod/admin.
2. User will receive the public welcome in general and a DM from the bot.
3. Welcome role will be automatically removed and the member role added.

This should prevent both the regions & roles commands (DiscoBot) from re-triggering a welcome message and also prevent Mercy from triggering the welcome message when a user becomes unrestricted.

Probably need assistance in testing this though I think my logic makes sense.

closes #296 