### PR TITLE
disable join record creation

### DIFF
--- a/index.js
+++ b/index.js
@@ -319,7 +319,7 @@ bot.on('message', message => {
 bot.on('guildMemberAdd', (member) => {
   try {
     events.memberJoined.process(bot, member);
-    events.updateAPI.process('join', bot, member);
+    //events.updateAPI.process('join', bot, member);
   } catch (e) {
     console.error(e.stack);
   }


### PR DESCRIPTION
there seems to be a race condition happening between the join of the server and the checking if a user had joined before.
For now we can rely on the fact a user will of 'joined' once they have the member status i.e. hit the update event