### PR TITLE
adds aws-sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "license": "GPL-2.0",
   "dependencies": {
+    "aws-sdk": "^2.82.0",
     "discord.js": "^11.0.0",
     "erlpack": "github:hammerandchisel/erlpack",
     "log-timestamp": "^0.1.2",


### PR DESCRIPTION
apparently this was missing from the package.json

New infrastructure flagged it - i can only assume this gets built into elastic beanstalk automatically