### PR TITLE
adds separate field to assist mobile

### DIFF
--- a/commands/joined.js
+++ b/commands/joined.js
@@ -51,7 +51,6 @@ module.exports = {
         moment(target.joinedAt).fromNow()
       );
 
-      embed.setTimestamp(target.joinedAt);
     }
 
     embed.setAuthor(
@@ -62,6 +61,7 @@ module.exports = {
 
     embed.addField('User:', target, true);
     embed.addField('Requested By:', message.author, true);
+    embed.addField('Date:', target.joinedAt, true);
 
     message.channel.send(
       'Here\'s ' +


### PR DESCRIPTION
Changes the embed timestamp to be its own field, this means it will be displayed correctly on mobile.

closes #273 

**Current**
- PC
<img width="524" alt="joined_pc_current" src="https://user-images.githubusercontent.com/9197696/28211136-5e7066ec-689b-11e7-8aaf-e561a62f1374.PNG">

- Mobile
![screenshot_20170714-134709 2](https://user-images.githubusercontent.com/9197696/28211159-7472e14a-689b-11e7-8f8a-4d6dd8881bbf.png)

**Proposed Changes**
- PC
<img width="451" alt="joined_pc_new" src="https://user-images.githubusercontent.com/9197696/28211139-6169da5e-689b-11e7-83ab-1a7679f9c95f.PNG">

- Mobile
![screenshot_20170714-134258 2](https://user-images.githubusercontent.com/9197696/28211151-6c1159f0-689b-11e7-8f15-d7d81ac4c996.png)