### PR TITLE
reimplements edits posted to #message-logs

### DIFF
--- a/events/messageUpdated.js
+++ b/events/messageUpdated.js
@@ -39,7 +39,7 @@ module.exports = {
     } else {
         embed.addField('Old Message', 'No Content');
     }
-    if (oldMessage.content) {
+    if (newMessage.content) {
         embed.addField('New Message', newMessage.content);
     } else {
         embed.addField('New Message', 'No Content');

--- a/events/messageUpdated.js
+++ b/events/messageUpdated.js
@@ -23,7 +23,7 @@ module.exports = {
   // Logs a message edit in #user-logs.
   process: (bot, oldMessage, newMessage) => {
     // Don't tag bot message updates
-    if (oldMessage.author === bot || newMessage.author === bot) return;
+    if (oldMessage.author === bot || newMessage.author === bot || oldMessage.content === newMessage.content) return;
 
     let messageLogsChannel = bot.channels.find('name', 'message-logs');
 
@@ -34,8 +34,16 @@ module.exports = {
     embed.addField('User', newMessage.author, true);
     embed.addField('Channel', newMessage.channel, true);
 
-    embed.addField('Old Message', oldMessage.content);
-    embed.addField('New Message', newMessage.content);
+    if (oldMessage.content) {
+        embed.addField('Old Message', oldMessage.content);
+    } else {
+        embed.addField('Old Message', 'No Content');
+    }
+    if (oldMessage.content) {
+        embed.addField('New Message', newMessage.content);
+    } else {
+        embed.addField('New Message', 'No Content');
+    }
 
     const embedDate = new Date(Date.now()).toISOString();
     embed.setTimestamp(embedDate);

--- a/index.js
+++ b/index.js
@@ -204,13 +204,13 @@ bot.on('messageDelete', (message) => {
 
 
 // Message edited
-//bot.on('messageUpdate', (oldMessage, newMessage) => {
-//  try {
-//    events.messageUpdated.process(bot, oldMessage, newMessage);
-//  } catch (e) {
-//    logger.error(e.stack);
-//  }
-//});
+bot.on('messageUpdate', (oldMessage, newMessage) => {
+ try {
+   events.messageUpdated.process(bot, oldMessage, newMessage);
+ } catch (e) {
+   logger.error(e.stack);
+ }
+});
 
 logger.info('Bot started');
 


### PR DESCRIPTION
closes #241 

This will reimplement the posting of edits to #message-logs.

I have tested this with standard edits and editing of messages with embeds and appears to operate correctly though may need more test cases, I will ask if there are any more on #241 