### PR TITLE
Don't emit errors! :scream_cat:

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -26,4 +26,6 @@ const logger = new (winston.Logger)({
     ]
   });
 
+logger.emitErrs = false;
+
 module.exports.logger = logger;


### PR DESCRIPTION
https://github.com/winstonjs/winston#events-and-callbacks-in-winston

> Each instance of winston.Logger is also an instance of an EventEmitter.
>
> It is also worth mentioning that the logger also emits an 'error' event which you should handle or suppress if you don't want unhandled exceptions.