### PR TITLE
Remove mod ping from welcome room message

### DIFF
--- a/events/memberJoined.js
+++ b/events/memberJoined.js
@@ -100,9 +100,7 @@ module.exports = {
         welcomeChannel.send('Welcome '+userReturnMsg+'to Gaymers, ' + member + '! ' +
             'Please introduce yourself, and check your DMs for more info! ' +
             'You will have access to other channels once you introduce ' +
-            'yourself. :smile:\n\n' +
-            'Feel free to tag a Moderator using `@Moderator` once you have ' +
-            'introduced yourself if they are taking too long to respond. :smile:') ;
+            'yourself. :smile:');
       }
 
       // DM the user more onboarding information


### PR DESCRIPTION
Per the staff meeting, mod pings are too much at this point. We're just ignoring them and this has a negative effect.