### PR TITLE
Add automatic age detection to introductions

### DIFF
--- a/MessageHandler.js
+++ b/MessageHandler.js
@@ -34,7 +34,10 @@ class MessageHandler {
       }
     }
 
-    // TODO: Handle automatic age detection in #introductions
+    if(Message.channel.name === `introductions`) {
+      this.introAgeDetection(Message);
+      return;
+    }
 
     if (!Message.content.startsWith(`!`)) return;
 
@@ -58,6 +61,22 @@ class MessageHandler {
     }
 
     command.execute(Message, args);
+  }
+
+  async introAgeDetection(Message) {
+    // Looking for 2 digit ages
+    const ageRegEx = /[\d][\d]/;
+    const memberAge = Message.content.match(ageRegEx);
+
+    // If no age listed, do nothing
+    if (!memberAge) return;
+
+    // Presume first numberical hit is the age
+    if (memberAge[0] < 18) {
+      const Role = await Message.guild.roles.cache.find(role => role.name === `Under 18`);
+      const Member = await Message.guild.members.fetch(Message.author.id);
+      Member.roles.add(Role);
+    }
   }
 }
 


### PR DESCRIPTION
Will attempt to automatically detect someone's age when they post an introductions post and apply the relevant role. Will only do so for Under 18 members, and won't attempt to re-add or remove any existing age roles.