### PR TITLE
Dynamic help command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ node_modules
 
 # Editor
 .vscode/settings.json
+.vscode/*.code-workspace

--- a/Commands/Avatar.js
+++ b/Commands/Avatar.js
@@ -5,8 +5,8 @@ class Avatar extends Command {
     super();
     this.name = `avatar`;
     this.aliases = [`pic`, `pfp`, `icon`];
-    this.description = `See a bigger version of someone\`s avatar`;
-    this.usage = `@someone`;
+    this.description = `See a bigger version of someone's avatar—or your own! Add the \`private avatar\` role in #roles to stop this command being used on you.`;
+    this.usage = `[@someone]`;
     this.serverOnly = true;
   }
 

--- a/Commands/Help.js
+++ b/Commands/Help.js
@@ -3,7 +3,7 @@ const fs = require(`fs`);
 const Discord = require('discord.js');
 
 class Help extends Command {
-  constructor() {
+  constructor(commands) {
     super();
     this.name = `help`;
     this.aliases = [`h`, `commands`, `halp`];
@@ -11,18 +11,7 @@ class Help extends Command {
     this.usage = ``;
     this.serverOnly = true;
 
-    // Dynamically load commands
-    // I know this means commands are loaded twice
-    // TODO: inherit these from the MessageHandler when Help is instantiated
-    this.commands = new Discord.Collection();
-
-    const commandFiles = fs.readdirSync(`./Commands`)
-      .filter(file => file.endsWith(`.js`))
-      .filter(file => file !== `Command.js`)
-      .filter(file => file !== `Help.js`)
-      .map(file => require(`../Commands/${file}`))
-      .filter(cmd => cmd.name)
-      .forEach(cmd => this.commands.set(cmd.name.toLowerCase(), new cmd()), this);
+    this.commands = commands;
   }
 
   async execute(Message) {

--- a/Commands/Help.js
+++ b/Commands/Help.js
@@ -1,0 +1,44 @@
+const Command = require(`./Command.js`);
+
+class Help extends Command {
+  constructor() {
+    super();
+    this.name = `help`;
+    this.aliases = [`h`, `commands`, `halp`];
+    this.description = `View available commands the bot can handle`;
+    this.usage = ``;
+    this.serverOnly = true;
+  }
+
+  async execute(Message) {
+        Message.channel.send({embed: {
+            color: `#d74894`,
+            author: {
+              name: Message.client.user.username,
+              icon_url: `https://cdn.discordapp.com/avatars/${Message.client.user.id}/${Message.client.user.avatar}.png`
+            },
+            title: `Here are the available Kirby commands`,
+            description: `Tip: for all commands do not include the square brackets "[]"`,
+            fields: [{
+                name: `!iplay [game]`,
+                value: `Tell us which games you play! This will add a pingable role so you can find other people to play with`
+              },
+              {
+                name: `!iplay`,
+                value: `See the list of available game roles`
+              },
+              {
+                name: `!joined [@someone]`,
+                value: `See when someone joined the server`
+              },
+              {
+                name: "!avatar [@someone]",
+                value: `See a bigger version of someone's avatar`
+              }
+            ]
+          }
+        });
+  }
+}
+
+module.exports = Help;

--- a/Commands/Help.js
+++ b/Commands/Help.js
@@ -1,43 +1,46 @@
 const Command = require(`./Command.js`);
+const fs = require(`fs`);
+const Discord = require('discord.js');
 
 class Help extends Command {
   constructor() {
     super();
     this.name = `help`;
     this.aliases = [`h`, `commands`, `halp`];
-    this.description = `View available commands the bot can handle`;
+    this.description = `View available commands the bot can handle.`;
     this.usage = ``;
     this.serverOnly = true;
+
+    // Dynamically load commands
+    // I know this means commands are loaded twice
+    // TODO: inherit these from the MessageHandler when Help is instantiated
+    this.commands = new Discord.Collection();
+
+    const commandFiles = fs.readdirSync(`./Commands`)
+      .filter(file => file.endsWith(`.js`))
+      .filter(file => file !== `Command.js`)
+      .filter(file => file !== `Help.js`)
+      .map(file => require(`../Commands/${file}`))
+      .filter(cmd => cmd.name)
+      .forEach(cmd => this.commands.set(cmd.name.toLowerCase(), new cmd()), this);
   }
 
   async execute(Message) {
-        Message.channel.send({embed: {
-            color: `#d74894`,
-            author: {
-              name: Message.client.user.username,
-              icon_url: `https://cdn.discordapp.com/avatars/${Message.client.user.id}/${Message.client.user.avatar}.png`
-            },
-            title: `Here are the available Kirby commands`,
-            description: `Tip: for all commands do not include the square brackets "[]"`,
-            fields: [{
-                name: `!iplay [game]`,
-                value: `Tell us which games you play! This will add a pingable role so you can find other people to play with`
-              },
-              {
-                name: `!iplay`,
-                value: `See the list of available game roles`
-              },
-              {
-                name: `!joined [@someone]`,
-                value: `See when someone joined the server`
-              },
-              {
-                name: `!avatar [@someone]`,
-                value: `See a bigger version of someone's avatar`
-              }
-            ]
-          }
-        });
+    const embed = new Discord.MessageEmbed();
+
+    embed.setColor(0xD74894);
+
+    const commands = this.commands
+    .filter(command => !command.staffOnly)
+    .filter(command => !command.disabled);
+
+    commands.forEach(command => {
+      embed.addField(`!${command.name} ${command.usage}`, command.description, false);
+    });
+
+    embed.setFooter(`Square brackets [] mean this part is optional. You don't need to include the brackets themselves in the command.`)
+
+    Message.reply(`Here's the commands you can use:`, {embed: embed});
   }
 }
 

--- a/Commands/Help.js
+++ b/Commands/Help.js
@@ -32,7 +32,7 @@ class Help extends Command {
                 value: `See when someone joined the server`
               },
               {
-                name: "!avatar [@someone]",
+                name: `!avatar [@someone]`,
                 value: `See a bigger version of someone's avatar`
               }
             ]

--- a/Commands/IPlay.js
+++ b/Commands/IPlay.js
@@ -7,8 +7,8 @@ class IPlay extends Command {
     super();
     this.name = `iplay`;
     this.aliases = [`role`, `roles`, `game`, `games`, `play`];
-    this.description = `Tell us which games you play!  This will add a pingable role so you can find other people to play with.`;
-    this.usage = ``;
+    this.description = `Tell us which games you play! Use the command on its own to see a list of available games. Use with a game to add a pingable role to yourself to be notified when others want to play.`;
+    this.usage = `[game]`;
     this.serverOnly = true;
     this.gameRoles = [];
     this.gameRolesLowerCase = [];

--- a/Commands/Joined.js
+++ b/Commands/Joined.js
@@ -7,8 +7,8 @@ class Joined extends Command {
     super();
     this.name = `joined`;
     this.aliases = [`joindate`];
-    this.description = `See when someone joined the server`;
-    this.usage = `@someone`;
+    this.description = `See when someone joined the server.`;
+    this.usage = `[@someone]`;
     this.serverOnly = true;
   }
 

--- a/Commands/Spell.js
+++ b/Commands/Spell.js
@@ -5,8 +5,8 @@ class Spell extends Command {
     super();
     this.name = `spell`;
     this.aliases = [`cast`];
-    this.description = `Cast some magic spells`;
-    this.usage = ``;
+    this.description = `Cast some magic spells.`;
+    this.usage = `[spell]`;
     this.serverOnly = true;
     this.staffOnly = true;
   }

--- a/Commands/UpdateRoles.js
+++ b/Commands/UpdateRoles.js
@@ -7,7 +7,7 @@ class UpdateRoles extends Command {
     super();
     this.name = `updateroles`;
     this.aliases = [`update-roles`];
-    this.description = `Update the role list in the #roles channel`;
+    this.description = `Update the role list in the #roles channel.`;
     this.usage = ``;
     this.serverOnly = true;
     this.staffOnly = true;

--- a/MessageHandler.js
+++ b/MessageHandler.js
@@ -10,9 +10,14 @@ class MessageHandler {
     const commandFiles = fs.readdirSync(`./Commands`)
       .filter(file => file.endsWith(`.js`))
       .filter(file => file !== 'Command.js')
+      .filter(file => file !== 'Help.js')
       .map(file => require(`./Commands/${file}`))
       .filter(cmd => cmd.name)
       .forEach(cmd => this.commands.set(cmd.name.toLowerCase(), new cmd()), this);
+
+    const helpCommand = require(`./Commands/Help.js`);
+
+    this.commands.set(helpCommand.name.toLowerCase(), new helpCommand(this.commands), this);
   }
 
   /**

--- a/MessageHandler.js
+++ b/MessageHandler.js
@@ -4,16 +4,15 @@ const roles = require(`./roles`);
 
 class MessageHandler {
   constructor() {
-    // Dynamically loadoad commands
+    // Dynamically load commands
     this.commands = new Discord.Collection();
-  
-    // this probably works.
+
     const commandFiles = fs.readdirSync(`./Commands`)
       .filter(file => file.endsWith(`.js`))
       .filter(file => file !== 'Command.js')
       .map(file => require(`./Commands/${file}`))
       .filter(cmd => cmd.name)
-      .forEach(cmd => this.commands.set(cmd.name.toLowerCase(), new cmd()), this)
+      .forEach(cmd => this.commands.set(cmd.name.toLowerCase(), new cmd()), this);
   }
 
   /**


### PR DESCRIPTION
Builds on top of #378 

@br0kenSubrout1ne I was testing your PR and decided to just invest a few mins in converting it to a dynamic command instead. That way all associated strings are loaded directly from the command files rather than embedded in Help.js or an external strings file. Also converts to using the rich embed builder rather than a big object as I personally find that easier to read and work with.

Still a bit messy as it ends up loading the command modules *twice,* once on command load and again inside the `!help` command, but I left a TODO in there to try and pass the commands object through to the Help command on its instantiation. 

I used your branch as a base though, so you'll still get the contributions! ✨ 

What it looks like:
![image](https://user-images.githubusercontent.com/2439407/97803624-e03a3200-1c4a-11eb-93ae-54746b3da95f.png)